### PR TITLE
parentesis faltando colocado

### DIFF
--- a/parsons_probs/fourfours.yaml
+++ b/parsons_probs/fourfours.yaml
@@ -24,7 +24,7 @@ code_lines: |
   print(!BLANK // !BLANK + !BLANK // !BLANK)
   print(!BLANK + !BLANK + !BLANK) // !BLANK)
   print(!BLANK + (!BLANK - !BLANK) // !BLANK)
-  print(!BLANK * !BLANK + !BLANK) // !BLANK)
+  print((!BLANK * !BLANK + !BLANK) // !BLANK)
   print(!BLANK + (!BLANK + !BLANK) // !BLANK)
   print(!BLANK + !BLANK - !BLANK // !BLANK)
   print(!BLANK + !BLANK + !BLANK - !BLANK)


### PR DESCRIPTION
correção de casamento de paresentesis